### PR TITLE
Add Fabric Client for Workloads as a trusted application

### DIFF
--- a/Authentication/CreateDevAADApp.ps1
+++ b/Authentication/CreateDevAADApp.ps1
@@ -35,6 +35,10 @@ if (-not $applicationName) {
 if (-not $workloadName) {
     $workloadName = Read-Host "Enter your workload name"
 }
+while (-not ($workloadName -match "^Org\.[^.]+$"))
+{
+    $workloadName = Read-Host "Workload name must start with Org. and contain only 2 segments!. please re-enter your workload name"
+}
 if (-not $tenantId) {
     $tenantId = Read-Host "Enter your tenant id (tenant id of the user you are using in Fabric to develop your workload)"
 }
@@ -127,9 +131,15 @@ $application = @{
                 delegatedPermissionIds = @(
                     $Item1ReadAllGuid, $Item1ReadWriteAllGuid, $FabricLakehouseReadAllGuid, $FabricLakehouseReadWriteAllGuid 
                 )
-            }
+            },
              @{
                 appId = "00000009-0000-0000-c000-000000000000"
+                delegatedPermissionIds = @(
+                    $FabricWorkloadControlGuid
+                )
+            },
+            @{
+                appId = "d2450708-699c-41e3-8077-b0c8341509aa"
                 delegatedPermissionIds = @(
                     $FabricWorkloadControlGuid
                 )

--- a/Backend/src/Constants/EnvironmentConstants.cs
+++ b/Backend/src/Constants/EnvironmentConstants.cs
@@ -15,6 +15,8 @@ namespace Boilerplate.Constants
 
         public const string FabricBackendAppId = "00000009-0000-0000-c000-000000000000";
 
+        public const string FabricClientForWorkloadsAppId = "d2450708-699c-41e3-8077-b0c8341509aa";
+
         public const string OneLakeResourceId = "https://storage.azure.com";
 
         public const string AadInstanceUrl = "https://login.microsoftonline.com";

--- a/Backend/src/Services/AuthenticationService.cs
+++ b/Backend/src/Services/AuthenticationService.cs
@@ -65,7 +65,7 @@ namespace Boilerplate.Services
                     tenantIdValues.Count != 1 ||
                     !Guid.TryParse(tenantIdValues.Single(), out var parsedTenantId))
                 {
-                        throw new AuthenticationException($"Missing or invalid {HttpHeaders.XmsClientTenantId} header");
+                    throw new AuthenticationException($"Missing or invalid {HttpHeaders.XmsClientTenantId} header");
                 }
 
                 tenantId = parsedTenantId;


### PR DESCRIPTION
Add Fabric Client for Workloads as a trusted application:
1. Add preauthorization step to preauthorize Fabric Client for Workloads for control plane scope.
2. Change validation of appId in the appOnly token in authentication service to validate one of 2 apps (Fabric App or Fabric Client for Workloads app).