### PR TITLE
Add Request Logging with Supportability Headers

### DIFF
--- a/Backend/src/Constants/HttpConstants.cs
+++ b/Backend/src/Constants/HttpConstants.cs
@@ -7,6 +7,8 @@ namespace Fabric_Extension_BE_Boilerplate.Constants
     public static class HttpHeaders
     {
         public const string Authorization = "Authorization";
+        public const string ActivityId = "ActivityId";
+        public const string RequestId = "RequestId";
         public const string XmsClientTenantId = "x-ms-client-tenant-id";
     }
 

--- a/Backend/src/Controllers/ItemLifecycleControllerImpl.cs
+++ b/Backend/src/Controllers/ItemLifecycleControllerImpl.cs
@@ -4,13 +4,16 @@
 
 using Boilerplate.Services;
 using Fabric_Extension_BE_Boilerplate.Contracts.FabricAPI.Workload;
+using Fabric_Extension_BE_Boilerplate.Utils;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 
 namespace Fabric_Extension_BE_Boilerplate.Controllers
 {
+    [ServiceFilter(typeof(RequestLoggingFilter))]
     internal class ItemLifecycleControllerImpl : IItemLifecycleController
     {
         private readonly IHttpContextAccessor _httpContextAccessor;

--- a/Backend/src/Controllers/JobsControllerImpl.cs
+++ b/Backend/src/Controllers/JobsControllerImpl.cs
@@ -5,7 +5,9 @@
 
 using Boilerplate.Services;
 using Fabric_Extension_BE_Boilerplate.Contracts.FabricAPI.Workload;
+using Fabric_Extension_BE_Boilerplate.Utils;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Net;
@@ -13,6 +15,7 @@ using System.Threading.Tasks;
 
 namespace Fabric_Extension_BE_Boilerplate.Controllers
 {
+    [ServiceFilter(typeof(RequestLoggingFilter))]
     internal class JobsControllerImpl : IJobsController
     {
         private readonly IHttpContextAccessor _httpContextAccessor;

--- a/Backend/src/Program.cs
+++ b/Backend/src/Program.cs
@@ -6,6 +6,7 @@ using Boilerplate.Constants;
 using Boilerplate.Services;
 using Fabric_Extension_BE_Boilerplate.Contracts.FabricAPI.Workload;
 using Fabric_Extension_BE_Boilerplate.Controllers;
+using Fabric_Extension_BE_Boilerplate.Utils;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
@@ -46,6 +47,9 @@ namespace Boilerplate
 
                         // Access to ASP.NET Core HttpContext
                         services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+
+                        // HTTP requests logging
+                        services.AddScoped<RequestLoggingFilter>();
 
                         // Microsoft Entra (Azure Active Directory) tokens validation and generation, authentication, authorization
                         AddOpenIdConnectConfigurationManager(services);

--- a/Backend/src/Startup.cs
+++ b/Backend/src/Startup.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using Boilerplate.Exceptions;
+using Fabric_Extension_BE_Boilerplate.Utils;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -28,6 +29,7 @@ namespace Boilerplate
                 .AddControllers(options =>
                 {
                     options.Filters.Add<HttpResponseExceptionFilter>();
+                    options.Filters.Add<RequestLoggingFilter>();
                 })
                 .AddNewtonsoftJson(options =>
                 {

--- a/Backend/src/Utils/RequestLoggingFilter.cs
+++ b/Backend/src/Utils/RequestLoggingFilter.cs
@@ -18,6 +18,13 @@ namespace Fabric_Extension_BE_Boilerplate.Utils
         private readonly ILogger<RequestLoggingFilter> _logger;
         private readonly IHttpContextAccessor _httpContextAccessor;
 
+        private static readonly List<string> HeaderKeysToLog = new List<string>
+        {
+            HttpHeaders.RequestId,
+            HttpHeaders.ActivityId,
+            HttpHeaders.XmsClientTenantId,
+        };
+
         public RequestLoggingFilter(ILogger<RequestLoggingFilter> logger, IHttpContextAccessor httpContextAccessor)
         {
             _logger = logger;
@@ -26,8 +33,8 @@ namespace Fabric_Extension_BE_Boilerplate.Utils
 
         public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
         {
-            var actionName = context.ActionDescriptor.DisplayName;
-            var arguments = context.ActionArguments;
+            var actionName = context.ActionDescriptor?.DisplayName ?? "UnknownAction";
+            var arguments = context.ActionArguments ?? new Dictionary<string, object>();
 
             var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
             var serializedArguments = JsonConvert.SerializeObject(arguments, Formatting.None);
@@ -43,14 +50,8 @@ namespace Fabric_Extension_BE_Boilerplate.Utils
         private static IDictionary<string, string> GetHeaders(HttpContext httpContext)
         {
             var headersToLog = new Dictionary<string, string>();
-            var headerKeys = new List<string>
-            {
-                HttpHeaders.RequestId,
-                HttpHeaders.ActivityId,
-                HttpHeaders.XmsClientTenantId,
-            };
-
-            foreach (var key in headerKeys)
+           
+            foreach (var key in HeaderKeysToLog)
             {
                 if (httpContext.Request.Headers.TryGetValue(key, out var headerValue))
                 {

--- a/Backend/src/Utils/RequestLoggingFilter.cs
+++ b/Backend/src/Utils/RequestLoggingFilter.cs
@@ -1,0 +1,64 @@
+﻿// <copyright company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+using Fabric_Extension_BE_Boilerplate.Constants;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Fabric_Extension_BE_Boilerplate.Utils
+{
+    public class RequestLoggingFilter : IAsyncActionFilter
+    {
+        private readonly ILogger<RequestLoggingFilter> _logger;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public RequestLoggingFilter(ILogger<RequestLoggingFilter> logger, IHttpContextAccessor httpContextAccessor)
+        {
+            _logger = logger;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+        {
+            var actionName = context.ActionDescriptor.DisplayName;
+            var arguments = context.ActionArguments;
+
+            var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
+            var serializedArguments = JsonConvert.SerializeObject(arguments, Formatting.None);
+            var headers = GetHeaders(_httpContextAccessor.HttpContext);
+            var serializedHeaders = JsonConvert.SerializeObject(headers, Formatting.None);
+
+            _logger.LogInformation("[{Timestamp}] {ActionName} - Args: {Arguments}, Headers: {Headers}",
+                                   timestamp, actionName, serializedArguments, serializedHeaders);
+
+            await next();
+        }
+
+        private static IDictionary<string, string> GetHeaders(HttpContext httpContext)
+        {
+            var headersToLog = new Dictionary<string, string>();
+            var headerKeys = new List<string>
+            {
+                HttpHeaders.RequestId,
+                HttpHeaders.ActivityId,
+                HttpHeaders.XmsClientTenantId,
+            };
+
+            foreach (var key in headerKeys)
+            {
+                if (httpContext.Request.Headers.TryGetValue(key, out var headerValue))
+                {
+                    headersToLog[key] = headerValue;
+                }
+            }
+
+            return headersToLog;
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces request logging for the CRUD and JOBS controllers in the code sample. The logging includes important request details along with specific headers. This enhancement improves the observability of the API endpoints by providing detailed request logs, which include critical headers for tracking and debugging purposes.

For reference, read more here: [Request Headers](https://learn.microsoft.com/en-us/fabric/workload-development-kit/supportability#request-headers) (Fabric's workload development kit supportability documentation).
