### PR TITLE
Default IsEndpointResolutionService to false

### DIFF
--- a/Backend/src/Packages/manifest/WorkloadManifest.xml
+++ b/Backend/src/Packages/manifest/WorkloadManifest.xml
@@ -14,7 +14,7 @@
           <ServiceEndpoint>
             <Name>Workload</Name>
             <Url>https://be.endpointurl.net/workload/resolve-api-path-placeholder</Url>
-            <IsEndpointResolutionService>true</IsEndpointResolutionService>
+            <IsEndpointResolutionService>false</IsEndpointResolutionService>
             <EndpointResolutionContext>
               <ResolutionContextProperty>WorkspaceRegion</ResolutionContextProperty>
               <ResolutionContextProperty>TenantId</ResolutionContextProperty>


### PR DESCRIPTION
We see many of our customers failing when moving to test/prod mode because their manifest has IsEndpointResolutionService set to true.

We can easily reduce some of this noise by changing the default manifest in our boilerplate sample to set this property to false (this also makes sense because initially I would image testing with single endpoint and only then moving to multi cluster).