### PR TITLE
use Azure CLI's @<file> convention to call az rest

### DIFF
--- a/Authentication/CreateDevAADApp.ps1
+++ b/Authentication/CreateDevAADApp.ps1
@@ -10,7 +10,13 @@ function PostAADRequest {
         [string]$body
     )
 
-    return az rest --method POST --url $url --body $body --headers "Content-Type=application/json"
+    # Use Azure CLI's @<file> to avoid issues with different shells / OSs.
+    # see https://learn.microsoft.com/en-us/cli/azure/use-azure-cli-successfully-troubleshooting#error-failed-to-parse-string-as-json
+    $tempFile = [System.IO.Path]::GetTempFileName()
+    $body | Out-File -FilePath $tempFile
+    $azrestResult = az rest --method POST --url $url --headers "Content-Type=application/json" --body "@$tempFile"
+    Remove-Item $tempFile
+    return $azrestResult
 }
 
 function PrintInfo {
@@ -198,7 +204,7 @@ $application = @{
 }
 
 # Convert to valid json format (escape the '"')
-$applicationJson = ( $application | ConvertTo-Json -Compress -Depth 10) -replace '"','\"'
+$applicationJson = ( $application | ConvertTo-Json -Compress -Depth 10)
 
 # Create application
 $result = PostAADRequest -url https://graph.microsoft.com/v1.0/applications -body $applicationJson
@@ -231,7 +237,7 @@ $passwordCreds = @{
 }
 
 # Convert to valid json format (escape the '"')
-$passwordCredsJson = ( $passwordCreds | ConvertTo-Json -Compress -Depth 10) -replace '"','\"'
+$passwordCredsJson = ( $passwordCreds | ConvertTo-Json -Compress -Depth 10)
 
 $addPasswordResult = PostAADRequest -url ("https://graph.microsoft.com/v1.0/applications/" + $applicationObjectId + "/addPassword") -body $passwordCredsJson
 $addPasswordObject = ($addPasswordResult | ConvertFrom-Json)

--- a/Authentication/CreateDevAADApp.ps1
+++ b/Authentication/CreateDevAADApp.ps1
@@ -51,11 +51,11 @@ if (-not $tenantId) {
 
 $redirectUri = "http://localhost:60006/close"
 
-$FabricWorkloadControlGuid = New-Guid
-$Item1ReadAllGuid = New-Guid
-$Item1ReadWriteAllGuid = New-Guid
-$FabricLakehouseReadAllGuid = New-Guid
-$FabricLakehouseReadWriteAllGuid = New-Guid
+$FabricWorkloadControlGuid = (New-Guid).ToString()
+$Item1ReadAllGuid = (New-Guid).ToString()
+$Item1ReadWriteAllGuid = (New-Guid).ToString()
+$FabricLakehouseReadAllGuid = (New-Guid).ToString()
+$FabricLakehouseReadWriteAllGuid = (New-Guid).ToString()
 
 ## Generate URI
 


### PR DESCRIPTION
Fixes #69 and #67 

To validate I suggest using the following `.devcontainer.json`:

```json
// For format details, see https://aka.ms/devcontainer.json. For config options, see the
// README at: https://github.com/devcontainers/templates/tree/main/src/universal
{
	"name": "Default Linux Universal",
	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
	"image": "mcr.microsoft.com/devcontainers/universal:2-linux",

	// Features to add to the dev container. More info: https://containers.dev/features.
	"features": {
		"ghcr.io/devcontainers/features/powershell:1" : {},
		"ghcr.io/devcontainers/features/azure-cli:1" : {}
	}

	// Use 'forwardPorts' to make a list of ports inside the container available locally.
	// "forwardPorts": [],

	// Use 'postCreateCommand' to run commands after the container is created.
	// "postCreateCommand": "uname -a",

	// Configure tool-specific properties.
	// "customizations": {},

	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
	// "remoteUser": "root"
}
```