### PR TITLE
[Authentication] - propagate errors to the client and handle them

### DIFF
--- a/Backend/src/Constants/ErrorCodes.cs
+++ b/Backend/src/Constants/ErrorCodes.cs
@@ -8,6 +8,11 @@ namespace Fabric_Extension_BE_Boilerplate.Constants
     {
         public const string InternalError = "InternalError";
 
+        public static class Authentication
+        {
+            public const string AuthUIRequired = "AuthUIRequired";
+        }
+
         public static class Security
         {
             public const string AccessDenied = "AccessDenied";

--- a/Backend/src/Exceptions/AuthenticationUIRequiredException.cs
+++ b/Backend/src/Exceptions/AuthenticationUIRequiredException.cs
@@ -1,0 +1,29 @@
+﻿// <copyright company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+using Microsoft.AspNetCore.Http;
+using Fabric_Extension_BE_Boilerplate.Constants;
+using Fabric_Extension_BE_Boilerplate.Contracts.FabricAPI.Workload;
+using System.Linq;
+
+namespace Fabric_Extension_BE_Boilerplate.Exceptions
+{
+    public class AuthenticationUIRequiredException : WorkloadExceptionBase
+    {
+        public static string AdditionalScopesToConsentName = "additionalScopesToConsent";
+        public static string ClaimsForCondtionalAccessPolicyName = "claimsForCondtionalAccessPolicy";
+        public AuthenticationUIRequiredException(string msalOriginalErrorMessage)
+            : base(
+                  httpStatusCode: StatusCodes.Status401Unauthorized,
+                  errorCode: ErrorCodes.Authentication.AuthUIRequired,
+                  messageTemplate: msalOriginalErrorMessage,
+                  messageParameters: null,
+                  errorSource: ErrorSource.System,
+                  isPermanent: false)
+        {
+        }
+
+        public string ClaimsForConditionalAccessPolicy => Details?.FirstOrDefault()?.AdditionalParameters?.Where(ap => ap.Name == ClaimsForCondtionalAccessPolicyName).FirstOrDefault()?.Value;
+    }
+}

--- a/Backend/src/Exceptions/HttpResponseExceptionFilter.cs
+++ b/Backend/src/Exceptions/HttpResponseExceptionFilter.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Logging;
-using Microsoft.Identity.Client;
 using System;
 using System.Security.Authentication;
 
@@ -31,10 +30,10 @@ namespace Boilerplate.Exceptions
         {
             switch (context.Exception)
             {
-                case MsalUiRequiredException msalUiRequiredException:
+                case AuthenticationUIRequiredException authenticationUIRequiredException:
                     _logger.LogError("Failed to acquire a token, user interaction is required, returning '401 Unauthorized' with WWW-Authenticate header");
-                    AuthenticationService.AddBearerClaimToResponse(msalUiRequiredException, context.HttpContext.Response);
-                    context.Result = new StatusCodeResult(StatusCodes.Status401Unauthorized);
+                    AuthenticationService.AddBearerClaimToResponse(authenticationUIRequiredException, context.HttpContext.Response);
+                    context.Result = authenticationUIRequiredException.ToHttpActionResult();
                     context.ExceptionHandled = true;
                     break;
 

--- a/Backend/test/Fabric_Extension_BE_Boilerplate_UnitTests/Controllers/ExceptionFilterTests.cs
+++ b/Backend/test/Fabric_Extension_BE_Boilerplate_UnitTests/Controllers/ExceptionFilterTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright company="Microsoft">
+﻿﻿// <copyright company="Microsoft">
 // Copyright (c) Microsoft. All rights reserved.
 // </copyright>
 
@@ -6,6 +6,7 @@ using Boilerplate.Controllers;
 using Boilerplate.Exceptions;
 using Fabric_Extension_BE_Boilerplate.Constants;
 using Fabric_Extension_BE_Boilerplate.Contracts.FabricAPI.Workload;
+using Fabric_Extension_BE_Boilerplate.Exceptions;
 using Microsoft.Identity.Client;
 using Microsoft.IdentityModel.Tokens;
 using NUnit.Framework;
@@ -20,12 +21,21 @@ namespace Boilerplate.Tests
         private static readonly Func<string, bool> NonEmptyStringValidator = (string v) => !v.IsNullOrEmpty();
 
         [Test]
-        public async Task MsalUiRequiredExceptionThrown()
+        public async Task AuthenticationUIRequiredExceptionThrown()
         {
+            var message = "message";
             await TestExceptionFilter(
-                new MsalUiRequiredException("code", "message"),
+                new AuthenticationUIRequiredException(message),
                 expectedStatusCode: HttpStatusCode.Unauthorized,
-                expectedHeaders: new[] { ("WWW-Authenticate", NonEmptyStringValidator) });
+                expectedHeaders: new[] { ("WWW-Authenticate", NonEmptyStringValidator) },
+                expectedBody: new ErrorResponse
+                {
+                    ErrorCode = ErrorCodes.Authentication.AuthUIRequired,
+                    Message = message,
+                    Source = ErrorSource.System,
+                    IsPermanent = false,
+                    MessageParameters = null
+                });
         }
 
         [Test]

--- a/Frontend/src/models/WorkloadExceptionsModel.ts
+++ b/Frontend/src/models/WorkloadExceptionsModel.ts
@@ -1,0 +1,17 @@
+// <copyright company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+/** Add here error interfaces that are defined in the workload backend and used to propagate exceptions in control plane APIs */
+
+// Error code for errors propagated from the workload backend
+export const FabricExternalWorkloadError = "FabricExternalWorkloadError";
+
+// Returned from the workload when interactive authentication is required
+export interface AuthenticationUIRequiredException {
+    ClaimsForConditionalAccessPolicy: string;
+    ScopesToConsent: string[];
+    ErrorMessage: string;
+}
+
+export const AuthUIRequired = "AuthUIRequired";


### PR DESCRIPTION
This PR adds handling for authentication UI required exceptions that occur in control plane APIs (such as crud & jobs) and also provides an example of how to propagate errors from the workload backend to the workload frontned.