### PR TITLE
Fix two minor mismatches

### DIFF
--- a/Backend/src/Packages/manifest/WorkloadManifest.xml
+++ b/Backend/src/Packages/manifest/WorkloadManifest.xml
@@ -13,7 +13,7 @@
         <Endpoints>
           <ServiceEndpoint>
             <Name>Workload</Name>
-            <Url>https://be.endpointurl.net/workload/resolve-api-path-placeholder</Url>
+            <Url>https://be.endpointurl.net/workload</Url>
             <IsEndpointResolutionService>false</IsEndpointResolutionService>
           </ServiceEndpoint>
           <ServiceEndpoint>

--- a/Frontend/tools/PublicToInternalTransformer.js
+++ b/Frontend/tools/PublicToInternalTransformer.js
@@ -64,7 +64,7 @@ class PublicToInternalTransformer {
 
     static ToInternal(publicItem, workloadName) {
         return new InternalTab({
-            name: publicItem.Name,
+            name: publicItem.name,
             displayName: `${publicItem.displayName}`,
             displayNamePlural: `${publicItem.displayNamePlural}`,
             artifactType: `${workloadName}.${publicItem.name}`,


### PR DESCRIPTION
1. EP resolution - when false, the URL should point to the workload's base URL and not the EP resolution URL
2. InternalTab transformer - capitalized 'N' in .Name cause and undefined value for the tab.name property