### PR TITLE
remove failing command

### DIFF
--- a/tools/DevGatewayContainer/Dockerfile
+++ b/tools/DevGatewayContainer/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update && apt-get install -y curl sudo unzip && \
     curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash && \
     curl ${DEV_GATEWAY_DOWNLOAD_URL} -O && \
     unzip -o DevGateway.zip -d DevGateway && \
-    mv DevGateway/net6.0/* DevGateway/ && \
     rm -rf DevGateway.zip && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/*


### PR DESCRIPTION
This PR removes an offending step from docker build since the DevGateway.zip file no longer contains the `net6.0` directory.