### PR TITLE
Fix argument order in json transformer

### DIFF
--- a/Frontend/tools/JsonProcessorHelper.js
+++ b/Frontend/tools/JsonProcessorHelper.js
@@ -70,7 +70,7 @@ class JsonProcessorHelper {
 
     processItemJson(jsonContent, isLocalized) {
         const publicItemSchema = Object.assign(new PublicItem, JSON.parse(jsonContent));
-        const {internalItemSchema, tab} = PublicToInternalTransformer.toInternal(publicItemSchema, this.workloadName, this.productName, isLocalized);
+        const {internalItemSchema, tab} = PublicToInternalTransformer.toInternal(publicItemSchema, this.workloadName, isLocalized, this.productName);
         this.internalFinalJson.artifacts.push(internalItemSchema);
         this.internalFinalJson.tabs.push(tab);
     }


### PR DESCRIPTION
This PR fixes missing "Item types" in workload hub L2 page in a workload development scenario
<img width="242" alt="image" src="https://github.com/user-attachments/assets/fcaab678-39ba-41d0-89b4-491d8cce4aaa" />