### PR TITLE
Add workspace id validation for GUID

### DIFF
--- a/scripts/Setup/Setup.ps1
+++ b/scripts/Setup/Setup.ps1
@@ -5,7 +5,7 @@ param (
     [String]$WorkloadName = "Org.MyWorkloadSample",
     # The display name of the workload, used in the Fabric portal
     [String]$WorkloadDisplayName = "My Sample Workload",
-    # The Workspace Id to use for development
+    # The Workspace Id to use for development (GUID)
     # If not provided, the user will be prompted to enter it.
     [String]$DevWorkspaceId = "00000000-0000-0000-0000-000000000000",
     # The Entra Application ID for the frontend
@@ -27,10 +27,11 @@ param (
 Write-Output "Setting up the environment..."
 $setupDevGatewayScript = Join-Path $PSScriptRoot "..\Setup\SetupDevGateway.ps1"
 if (Test-Path $setupDevGatewayScript) {
-    if ([string]::IsNullOrWhiteSpace($DevWorkspaceId) -or $DevWorkspaceId -eq "00000000-0000-0000-0000-000000000000") {
+    $parsedGuid = [System.Guid]::Empty
+    if ([string]::IsNullOrWhiteSpace($DevWorkspaceId) -or $DevWorkspaceId -eq "00000000-0000-0000-0000-000000000000" -or -not [System.Guid]::TryParse($DevWorkspaceId, [ref]$parsedGuid)) {
         $DevWorkspaceId = Read-Host "Enter your Workspace Id that should be used for development"
-        if ([string]::IsNullOrWhiteSpace($DevWorkspaceId) -or $DevWorkspaceId -eq "00000000-0000-0000-0000-000000000000") {
-           Write-Error "Workspace Id is not set or is using the default placeholder value. Please provide a valid Workspace Id."
+        if ([string]::IsNullOrWhiteSpace($DevWorkspaceId) -or $DevWorkspaceId -eq "00000000-0000-0000-0000-000000000000" -or -not [System.Guid]::TryParse($DevWorkspaceId, [ref]$parsedGuid)) {
+           Write-Error "Workspace Id is not set, is empty, or is not a valid GUID. Please provide a valid Workspace Id."
            exit 1
         }
     }


### PR DESCRIPTION
Hello there from TSI 👋 

We are working on putting our Fabric solution onto the WDKv2 rails. Currently we are trying to deploy the sample app to our tenant.

The setup script is very convenient, I just noticed a small missing validation for the `$DevWorkspaceId`. 

If it's not a valid GUID, the script passes through, but then `StartDevGateway.ps1` explodes with this:
```
Unhandled exception. System.InvalidOperationException: Failed to convert configuration value at 'DevMode:WorkspaceGuid' to type 'System.Guid'.
 ---> System.FormatException: Unrecognized Guid format.
   at System.Guid.GuidResult.SetFailure(ParseFailure failureKind)
   at System.Guid.TryParseGuid(ReadOnlySpan`1 guidString, GuidResult& result)
   at System.Guid..ctor(String g)
   at System.ComponentModel.GuidConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.TryConvertValue(Type type, String value, String path, Object& result, Exception& error)
   --- End of inner exception stack trace ---
   at Microsoft.Extensions.Configuration.ConfigurationBinder.BindInstance(Type type, BindingPoint bindingPoint, IConfiguration config, BinderOptions options, Boolean isParentCollection)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.BindProperty(PropertyInfo property, Object instance, IConfiguration config, BinderOptions options)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.BindProperties(Object instance, IConfiguration configuration, BinderOptions options)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.BindInstance(Type type, BindingPoint bindingPoint, IConfiguration config, BinderOptions options, Boolean isParentCollection)
   at Microsoft.Extensions.Configuration.ConfigurationBinder.Bind(IConfiguration configuration, Object instance, Action`1 configureOptions)
   at Microsoft.Fabric.Relay.Connections.ServiceCollectionFabricRelayConnectionsExtensions.TryGetDevModeOptions[TConnectionOptions](TConnectionOptions& options, IEnumerable`1 validations, IDictionary`2 additionalCommandArgs)
   at Microsoft.Fabric.Relay.Connections.ServiceCollectionFabricRelayConnectionsExtensions.AddRelayConnections[TConnectionOptions](IServiceCollection services, Func`2 endpointMappingsFactory, Dictionary`2 additionalCommandArgsMappings, ValueTuple`2[] validationRules)
   at Microsoft.Fabric.Workloads.DevGateway.Program.<>c.<Main>b__0_0(HostBuilderContext _, IServiceCollection services)
   at Microsoft.Extensions.Hosting.HostBuilder.InitializeServiceProvider()
   at Microsoft.Extensions.Hosting.HostBuilder.Build()
   at Microsoft.Fabric.Workloads.DevGateway.Program.Main(String[] args)
   at Microsoft.Fabric.Workloads.DevGateway.Program.<Main>(String[] args)
```

So I am adding a check here on top of the emptiness check.

Let me know if you want to make it nicer or add some loop for this - currently for zeroes or bad GUID the script just exits (with a clear message though).