### PR TITLE
Update @ms-fabric/workload-client version range

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -14,7 +14,7 @@
     "@fluentui/react": "^8.110.7",
     "@fluentui/react-components": "^9.7.2",
     "@fluentui/react-icons": "2.0.226",
-    "@ms-fabric/workload-client": "^2.1.0",
+    "@ms-fabric/workload-client": ">2.0.0 <3.0.0",
     "@reduxjs/toolkit": "^2.6.0",
     "history": "^4.9.0",
     "i18next": "^23.12.3",


### PR DESCRIPTION
This PR constrains `@ms-fabric/workload-client` to `>2.0.0 <3.0.0` since upcoming version of ^3.x.x are planned for WDK v2.